### PR TITLE
chore: fix ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Adds `pnpm` setup step to CI workflow, mirroring what is done [in the CD workflow](https://github.com/reifiedbeans/find-gh-commit-emails/blob/35f25a56d56d79c6915c8c68b1845570686c3823/.github/workflows/cd.yaml#L19-L22)
