### PR TITLE
chore: add provenance tracking and use trusted publishing

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -27,8 +28,9 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install
+      - name: Verify dependency signatures
+        run: npm audit signatures
       - name: Publish release
         run: pnpx semantic-release@25
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "typescript": "^5.5.3"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "release": {
     "preset": "conventionalcommits"


### PR DESCRIPTION
NPM no longer supports long-lived access tokens. This is the recommended method for automated publishing.

https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#trusted-publishing-and-npm-provenance

https://docs.npmjs.com/trusted-publishers#how-trusted-publishing-works